### PR TITLE
Enable  Concurrency in `HttpHostResolver`

### DIFF
--- a/src/App/Web/packages.lock.json
+++ b/src/App/Web/packages.lock.json
@@ -646,6 +646,11 @@
         "resolved": "14.0.0",
         "contentHash": "jGOuTH1l+TCpJH+fwYOp7USzHDuGfN1jKbLz3J2COwyn+wL08eynvpnM6rY2qkzIEXum3PN2p2QkP3BW/p9Qcw=="
       },
+      "Open.ChannelExtensions": {
+        "type": "Transitive",
+        "resolved": "9.1.0",
+        "contentHash": "D6c24vMGy1oZ06vmkD2/FNzWHK7ZIihuv2spDgYEeaUp+eobrILQnrNQKRoASFXD4JGfZ7nfvTM0e+AX79dt8Q=="
+      },
       "OpenTelemetry": {
         "type": "Transitive",
         "resolved": "1.13.1",
@@ -804,6 +809,7 @@
           "ESCd.Extensions.Caching": "[1.1.1, )",
           "ESCd.Extensions.Http": "[1.0.14, )",
           "Microsoft.Extensions.Http.Resilience": "[9.10.0, )",
+          "Open.ChannelExtensions": "[9.1.0, )",
           "System.Linq.Async": "[6.0.3, )"
         }
       }

--- a/src/Extensions/RadioBrowser/Wadio.Extensions.RadioBrowser.csproj
+++ b/src/Extensions/RadioBrowser/Wadio.Extensions.RadioBrowser.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="ESCd.Extensions.Caching" Version="1.1.1" />
     <PackageReference Include="ESCd.Extensions.Http" Version="1.0.14" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
+    <PackageReference Include="Open.ChannelExtensions" Version="9.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions/RadioBrowser/packages.lock.json
+++ b/src/Extensions/RadioBrowser/packages.lock.json
@@ -57,6 +57,12 @@
         "resolved": "6.0.0",
         "contentHash": "+/SsmiySsXJlvQLCGBqaZKNVt3s/Y/HbAdwtop7Km2CnuZbaScoqkWJEBQ5Cy9ebkn6kCYKrHsXgwrFdTgcb3g=="
       },
+      "Open.ChannelExtensions": {
+        "type": "Direct",
+        "requested": "[9.1.0, )",
+        "resolved": "9.1.0",
+        "contentHash": "D6c24vMGy1oZ06vmkD2/FNzWHK7ZIihuv2spDgYEeaUp+eobrILQnrNQKRoASFXD4JGfZ7nfvTM0e+AX79dt8Q=="
+      },
       "System.Linq.Async": {
         "type": "Direct",
         "requested": "[6.0.3, )",

--- a/tool/MetadataScraper/packages.lock.json
+++ b/tool/MetadataScraper/packages.lock.json
@@ -387,6 +387,7 @@
           "ESCd.Extensions.Caching": "[1.1.1, )",
           "ESCd.Extensions.Http": "[1.0.14, )",
           "Microsoft.Extensions.Http.Resilience": "[9.10.0, )",
+          "Open.ChannelExtensions": "[9.1.0, )",
           "System.Linq.Async": "[6.0.3, )"
         }
       }


### PR DESCRIPTION
Updates the `HttpHostResolver` to use `Open.ChannelExtensions` when resolving host candidates from tracker urls, as well as when resolving the host from the candidates.

This improves resolution speed, further improving the app start-up speed.