### PR TITLE
Support Persistence of `SearchState`

### DIFF
--- a/src/App/UI/Components/ComponentsJsonContext.cs
+++ b/src/App/UI/Components/ComponentsJsonContext.cs
@@ -1,0 +1,9 @@
+using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+using Wadio.App.UI.Components.Forms;
+
+namespace Wadio.App.UI.Components;
+
+[JsonSerializable( typeof( ImmutableArray<FilterOption> ) )]
+[JsonSourceGenerationOptions( DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, WriteIndented = false )]
+public sealed partial class ComponentsJsonContext : JsonSerializerContext;

--- a/src/App/UI/Components/Forms/EditContextExtensions.cs
+++ b/src/App/UI/Components/Forms/EditContextExtensions.cs
@@ -1,0 +1,27 @@
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Wadio.App.UI.Components.Forms;
+
+internal static class EditContextExtensions
+{
+    public static IDisposable AddFieldChangedListener( this EditContext context, Action<EditContext, FieldChangedEventArgs> handler )
+    {
+        ArgumentNullException.ThrowIfNull( context );
+        ArgumentNullException.ThrowIfNull( handler );
+
+        context.OnFieldChanged += Handler;
+        return new OnFieldChangedListener( context, Handler );
+
+        void Handler( object? sender, FieldChangedEventArgs e )
+        {
+            var context = Unsafe.As<EditContext>( sender )!;
+            handler( context, e );
+        }
+    }
+}
+
+sealed file class OnFieldChangedListener( EditContext context, EventHandler<FieldChangedEventArgs> handler ) : IDisposable
+{
+    public void Dispose( ) => context.OnFieldChanged -= handler;
+}

--- a/src/App/UI/Components/Forms/InputFilter.razor
+++ b/src/App/UI/Components/Forms/InputFilter.razor
@@ -6,14 +6,14 @@
 
 @typeparam TValue
 
-<div @attributes="@AdditionalAttributes" class=@ClassNames.Combine(AdditionalAttributes, "bg-crust flex flex-col isolate overflow-auto p-1.5 rounded-sm shadow-sm transition", @EditContext?.FieldCssClass(fieldId)) role="listbox">
+<div @attributes="@AdditionalAttributes" class=@ClassNames.Combine(AdditionalAttributes, "bg-crust flex flex-col isolate overflow-y-auto p-1.5 rounded-sm shadow-sm transition", @EditContext?.FieldCssClass(fieldId)) role="listbox">
     @if (Filter is not null)
     {
-        <input class="bg-mantle! mb-2 ring-accent-subtle sticky top-0 z-10" @bind="@filter" @bind:event="oninput" placeholder="Filter..." type="text" disabled="@(Disabled || options.Length is 0)" title="Filter..." />
+        <input class="bg-mantle! mb-2 ring-accent-subtle sticky top-0 z-10" @bind="@query" @bind:event="oninput" placeholder="Filter..." type="text" disabled="@(Disabled || options.Count is 0)" title="Filter..." />
     }
 
-    <div class="flex flex-col px-1 w-full">
-        <Virtualize Items="@(Filter is not null && !string.IsNullOrWhiteSpace(filter) ? [.. options.Where(option => Filter.OnFiltering(option, filter, option.Value))] : options)" Context="option" ItemSize="24">
+    <div class="flex flex-col h-full px-1 w-full">
+        <Virtualize Items="@Filtered(Filter, options, query)" Context="option" ItemSize="24">
             <ItemContent>
                 <label class="flex flex-row items-center my-2 space-x-2.5 text-sm" role="listitem" @key="@option.Value">
                     <input class="bg-mantle! checked:bg-accent!" checked="@Value?.Equals(option.Value)" @onchange="(e => OnChange(e, option.Value))" type="checkbox" disabled="@Disabled" />
@@ -22,9 +22,9 @@
             </ItemContent>
 
             <EmptyContent>
-                @if (string.IsNullOrWhiteSpace(filter))
+                @if (string.IsNullOrWhiteSpace(query))
                 {
-                    <div class="flex flex-row h-full items-center justify-center">
+                    <div class="flex h-full items-center justify-center w-full">
                         <Loading Size="@TextSize.ExtraLarge" />
                     </div>
                 }
@@ -35,9 +35,9 @@
 
 @code {
 
-    private ValueOption[] options = [];
+    private ICollection<ValueOption> options = [];
     private FieldIdentifier fieldId;
-    private string? filter;
+    private string? query;
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; init; }
@@ -63,6 +63,18 @@
 
     [Parameter]
     public Expression<Func<TValue?>>? ValueExpression { get; init; }
+
+    private static ICollection<ValueOption> Filtered(IInputFilterProvider<TValue>? filter, ICollection<ValueOption> options, string? query)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (filter is not null && !string.IsNullOrWhiteSpace(query))
+        {
+            return [.. options.Where(option => filter.OnFiltering(option, query, option.Value))];
+        }
+
+        return options;
+    }
 
     private async Task OnChange(ChangeEventArgs e, TValue value)
     {

--- a/src/App/UI/Components/Forms/InputFilter.razor.cs
+++ b/src/App/UI/Components/Forms/InputFilter.razor.cs
@@ -4,10 +4,7 @@ namespace Wadio.App.UI.Components.Forms;
 
 public partial class InputFilter<[DynamicallyAccessedMembers( DynamicallyAccessedMemberTypes.All )] TValue>;
 
-public sealed record FilterOption( string Label, object Value )
-{
-    public long? Count { get; init; }
-}
+public sealed record FilterOption( string Label, object Value, long? Count = default );
 
 public interface IInputFilterProvider<T>
 {

--- a/src/App/UI/Components/Forms/InputFilterEnum.razor
+++ b/src/App/UI/Components/Forms/InputFilterEnum.razor
@@ -4,7 +4,7 @@
 
 @typeparam TValue where TValue : struct, Enum
 
-<InputFilter @attributes="@AdditionalAttributes" TValue="TValue?" Value="@Value" ValueChanged="@ValueChanged" ValueExpression="@ValueExpression" Options="@options" />
+<InputFilter @attributes="@AdditionalAttributes" TValue="TValue ?" Disabled="@Disabled" Value="@Value" ValueChanged="@ValueChanged" ValueExpression="@ValueExpression" Options="@options" />
 
 @code {
 
@@ -12,6 +12,9 @@
 
     [Parameter(CaptureUnmatchedValues = true)]
     public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; init; }
+
+    [Parameter]
+    public bool Disabled { get; init; }
 
     [Parameter]
     public TValue? Value { get; set; }

--- a/src/App/UI/Components/Layout/AppLayout.razor
+++ b/src/App/UI/Components/Layout/AppLayout.razor
@@ -1,4 +1,5 @@
 @using Wadio.App.UI.Components.Routing
+@using Wadio.App.UI.Infrastructure
 
 @inherits Stateful<AppLayoutState>
 @implements IAsyncDisposable
@@ -43,12 +44,10 @@
     public async ValueTask DisposeAsync()
     {
         Dispose(true);
-        foreach (var listener in listeners)
-        {
-            await listener.DisposeAsync();
-        }
 
+        await Disposer.DisposeAsync(listeners);
         listeners.Clear();
+
         await player.DisposeAsync();
     }
 

--- a/src/App/UI/Components/Layout/Header.razor
+++ b/src/App/UI/Components/Layout/Header.razor
@@ -1,7 +1,9 @@
 @using System.Globalization
+@using System.Runtime.CompilerServices
 @using Humanizer
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.WebUtilities
+@using Wadio.App.UI.Infrastructure
 
 @inherits Stateful<HeaderState>
 @implements IAsyncDisposable
@@ -23,11 +25,11 @@
             @if (State.History is not null)
             {
                 <button class="icon font-extrabold p-2.5!" type="button" title="Back" @onclick="@OnBackClick" disabled="@(!State.History.IsBackwardSupported)">
-                    <Icon Name="@IconName.ArrowBack" Size="@TextSize.ExtraLarge2" />
+                    <Icon Name="@IconName.ArrowBack" Size="@TextSize.ExtraLarge" />
                 </button>
 
                 <button class="icon font-extrabold p-2.5! hidden! md:flex!" type="button" title="Back" @onclick="@OnForwardClick" disabled="@(!State.History.IsForwardSupported)">
-                    <Icon Name="@IconName.ArrowForward" Size="@TextSize.ExtraLarge2" />
+                    <Icon Name="@IconName.ArrowForward" Size="@TextSize.ExtraLarge" />
                 </button>
             }
 
@@ -36,37 +38,40 @@
             </a>
         </div>
 
-        <div @ref="@container" class="flex flex-row items-center justify-center mr-2.5 md:mr-6.5 relative w-full md:max-w-1/2 lg:max-w-1/3" @onclickout="@CancelAndReset">
+        <div @ref="@container" class=@ClassNames.Combine("flex flex-row items-center justify-center mr-2.5 md:mr-6.5 relative w-full md:max-w-1/2 lg:max-w-1/3", State.History is not null ? "md:-ml-24" : "") @onclickout="@CancelAndReset">
             <form class="flex flex-row items-center relative w-full" rel="search" role="search" @onsubmit="@OnSearchSubmit">
-                <input class="backdrop-crust text-xl w-full placeholder:font-semibold" placeholder="Search Stations..." type="text" value="@query" @oninput="@OnSearchInput" />
-                <button class="absolute icon end-2" title="Search" type="submit" disabled="@string.IsNullOrWhiteSpace(query)">
+                <input @ref="@input" class="backdrop-crust text-xl w-full placeholder:font-semibold" placeholder="Search Stations..." type="text" value="@query" @oninput="@OnSearchInput" />
+                <button class="absolute dark icon end-2" title="Search" type="submit" disabled="@string.IsNullOrWhiteSpace(query)">
                     <Icon Name="@IconName.Search" Size="@TextSize.ExtraLarge2" />
                 </button>
             </form>
 
             @if (State.Stations.HasValue)
             {
-                <div class="absolute mt-4 mx-0 px-2.5 md:px-1.5 top-full w-screen z-20 md:w-full">
+                <div class="absolute mt-2.5 mx-0 px-2.5 md:px-1.5 top-full w-screen z-20 md:w-full">
                     <div class="bg-mantle backdrop-mantle flex flex-col items-center p-2 ring-accent-dark rounded-sm shadow-sm w-full">
                         @if (!State.IsLoading)
                         {
                             <ul class="space-y-2 w-full">
                                 @foreach (var station in State.Stations)
                                 {
-                                    <li class="p-2.5 rounded-md active:bg-crust active:ring-accent-light active:shadow-sm hover:bg-crust hover:ring-accent-light hover:shadow-sm" @key="@station.Id">
+                                    <li class="ease-in p-1.5 rounded-md transition active:bg-crust active:ring-accent-light active:shadow-sm hover:bg-crust hover:ring-accent-light hover:shadow-sm" @key="@station.Id">
                                         <a class="flex flex-row group items-center space-x-4" href="/station/@station.Id" title="@station.Name">
                                             <StationArt class="size-10" IsInteractive="false" IsMetaVisible="false" Station="@station" />
-                                            <Marquee class="ease-in font-medium text-gray-400 text-lg transition w-full" Mode="@(MarqueeMode.Active | MarqueeMode.Hover)" Speed="@MarqueeSpeed.Slow" Text="@station.Name" />
+                                            <Marquee class="font-medium text-gray-400 text-lg w-full" Mode="@(MarqueeMode.Active | MarqueeMode.Hover)" Speed="@MarqueeSpeed.Slow" Text="@station.Name" />
+                                            <div class="btn dark end-0 hidden! md:flex! icon items-center justify-center opacity-0 transition-opacity group-active:flex! group-active:opacity-100 group-hover:flex! group-hover:opacity-100">
+                                                <Icon Name="@IconName.ArrowForward" Size="@TextSize.ExtraLarge" />
+                                            </div>
                                         </a>
                                     </li>
                                 }
 
-                                <li class="p-2.5 rounded-md active:bg-crust active:ring-accent-light active:shadow-sm hover:bg-crust hover:ring-accent-light hover:shadow-sm">
-                                    <div class="cursor-pointer flex flex-row items-center space-x-4" role="button" @onclick="@OnSearchSubmit">
-                                        <div class="flex items-center justify-center w-10">
+                                <li class="ease-in p-1.5 pl-2.5 rounded-md transition active:bg-crust active:ring-accent-light active:shadow-sm hover:bg-crust hover:ring-accent-light hover:shadow-sm">
+                                    <div class="cursor-pointer flex flex-row items-center space-x-4 justify-between" role="button" @onclick="@OnSearchSubmit">
+                                        <div>View More...</div>
+                                        <div class="btn dark flex icon items-center justify-center">
                                             <Icon Name="@IconName.ArrowForward" Size="@TextSize.ExtraLarge" />
                                         </div>
-                                        <span>View More...</span>
                                     </div>
                                 </li>
                             </ul>
@@ -81,7 +86,7 @@
         </div>
 
         <div class="inline-block relative">
-            <button class="icon p-2.5! font-extrabold" type="button" title="App Info" @onclick="@OnAboutClick" rel="help">
+            <button class="icon p-2.5! font-extrabold" type="button" title="About" @onclick="@OnAboutClick" rel="help">
                 <Icon Name="@IconName.Help" Filled="false" Size="@TextSize.ExtraLarge" />
             </button>
 
@@ -95,7 +100,7 @@
 
 <Dialog @ref="@dialog" OnClose="OnAboutClose">
     <div class="flex flex-row font-medium items-center justify-between">
-        <h1 class="drop-shadow-md font-bold font-logo text-6xl text-accent/95 transition hover:drop-shadow-xl">Wadio</h1>
+        <h1 class="drop-shadow-lg font-bold font-logo text-6xl text-accent/95 transition">Wadio</h1>
         <a class="ease-in opacity-90 transition-opacity hover:opacity-100" href="https://github.com/ESCd/wadio" target="_blank" title="Wadio on GitHub">
             <img class="h-4.5" src="/github-logo.svg" alt="GitHub logo" />
         </a>
@@ -191,12 +196,15 @@
 @code {
 
     private static readonly TimeSpan OutdatedRefreshRate = TimeSpan.FromMinutes(15);
+    private const string SearchPath = "/search";
 
     private CancellationTokenSource cancellation = new();
     private ElementReference container;
     private Dialog dialog;
+    private ElementReference input;
     private string? query;
     private List<IAsyncDisposable> listeners = [];
+    private IDisposable? location;
 
     [EditorRequired]
     [Parameter]
@@ -228,6 +236,7 @@
             cancellation.Dispose();
             cancellation = default!;
 
+            location?.Dispose();
             Navigation.LocationChanged -= OnLocationChanged;
         }
     }
@@ -235,11 +244,8 @@
     public async ValueTask DisposeAsync()
     {
         Dispose(true);
-        foreach (var listener in listeners)
-        {
-            await listener.DisposeAsync();
-        }
 
+        await Disposer.DisposeAsync(listeners);
         listeners.Clear();
     }
 
@@ -266,7 +272,9 @@
         {
             await Mutate(state => HeaderState.LoadHistorySupport(Dom, History, state));
 
+            location = Navigation.RegisterLocationChangingHandler(OnLocationChanging);
             Navigation.LocationChanged += OnLocationChanged;
+
             listeners.Add(await Dom.AddAppInstalledListener(OnAppInstalled));
             listeners.Add(await Dom.AddClickOutListener(container));
             listeners.Add(await Dom.AddFullscreenChangeListener(OnFullscreenChange));
@@ -284,7 +292,7 @@
     {
         ArgumentNullException.ThrowIfNull(state);
 
-        var header = (Header)state;
+        var header = Unsafe.As<Header>(state);
         await header.Mutate(state => HeaderState.RefreshOutdated(header.Api, state));
     }
 
@@ -296,13 +304,27 @@
         return Task.CompletedTask;
     }
 
-    private async void OnLocationChanged(object? _, LocationChangedEventArgs e)
+    private async ValueTask OnLocationChanging(LocationChangingContext context)
     {
         await CancelAndReset();
+
+        var current = new Uri(Navigation.Uri);
+        if (Uri.TryCreate(context.TargetLocation, UriKind.RelativeOrAbsolute, out var target))
+        {
+            if (current.AbsolutePath.StartsWith(SearchPath) && target.AbsolutePath.StartsWith(SearchPath))
+            {
+                await input.FocusAsync();
+                context.PreventNavigation();
+            }
+        }
+    }
+
+    private async void OnLocationChanged(object? _, LocationChangedEventArgs e)
+    {
         if (Uri.TryCreate(e.Location, UriKind.RelativeOrAbsolute, out var url))
         {
             query = default;
-            if (url.AbsolutePath.StartsWith("/search"))
+            if (url.AbsolutePath.StartsWith(SearchPath))
             {
                 QueryHelpers.ParseQuery(url.Query).TryGetValue(nameof(Pages.Search.Name), out var name);
                 query = name;

--- a/src/App/UI/Components/Layout/Navigation.razor
+++ b/src/App/UI/Components/Layout/Navigation.razor
@@ -2,41 +2,28 @@
 
 <nav class=@ClassNames.Combine("backdrop-mantle drop-shadow-sm ease-in flex flex-row md:flex-col h-full isolate items-stretch md:items-center justify-center md:justify-start overflow-y-auto p-1.5 md:p-2.5 ring-accent-dark rounded-t-md md:rounded-md shadow-sm space-x-2 md:space-x-0 md:space-y-2 transition transition-width", IsMenuOpen ? "opacity-100 w-full" : "hidden opacity-0 md:flex md:opacity-100")>
     <div class="w-full md:hidden">
-        <NavLink ActiveClass="bg-crust font-bold ring-accent-light shadow-sm" class=@ClassNames.Combine("drop-shadow-sm ease-in flex flex-col md:flex-row font-semibold h-full items-center justify-center md:justify-start no-underline p-1 md:p-0 rounded-md transition w-full active:bg-crust active:ring-accent-light active:shadow-sm hover:bg-crust hover:ring-accent-light hover:shadow-sm", !IsMenuOpen ? "justify-center" : "") href="/" title="Discover" Match="@NavLinkMatch.All">
-            <div class="flex items-center justify-center p-1.5 md:p-3">
-                <Icon class="md:text-2xl" Name="@IconName.Home" Filled="false" Size="@TextSize.ExtraLarge" />
-            </div>
-            <span class=@ClassNames.Combine("ease-in font-semibold md:ml-0.5 md:mr-2.5 p-0.5 md:p-2 rounded-md text-xs md:text-lg transition", !IsMenuOpen ? "hidden opacity-0" : "opacity-100")>Home</span>
-        </NavLink>
+        @NavLink(NavigationItems.Home)
     </div>
 
-    @foreach (var item in NavigationItems.Values)
+    @foreach (var item in NavigationItems.All)
     {
         <div class="w-full">
-            <NavLink ActiveClass="bg-crust font-bold ring-accent-light shadow-sm" class=@ClassNames.Combine("drop-shadow-sm ease-in flex flex-col md:flex-row font-semibold h-full items-center justify-center md:justify-start no-underline p-1 md:p-0 rounded-md transition w-full active:bg-crust active:ring-accent-light active:shadow-sm hover:bg-crust hover:ring-accent-light hover:shadow-sm", !IsMenuOpen ? "justify-center" : "") href="@item.Path" title="@item.Label" Match="@item.Match" @key="@item.Path">
-                <div class="flex items-center justify-center p-1.5 md:p-3">
-                    <Icon class="md:text-2xl" Name="@item.Icon" Filled="false" Size="@TextSize.ExtraLarge" />
-                </div>
-                <span class=@ClassNames.Combine("ease-in font-semibold md:ml-0.5 md:mr-2.5 p-0.5 md:p-2 rounded-md text-xs md:text-lg transition", !IsMenuOpen ? "hidden opacity-0" : "opacity-100")>@item.Label</span>
-            </NavLink>
+            @NavLink(item)
         </div>
     }
 
-    <div class="flex-grow hidden md:block"></div>
+    <div class="grow hidden md:block"></div>
 
     <div class="w-full">
-        <span class=@ClassNames.Combine("cursor-pointer drop-shadow-sm ease-in flex flex-col md:flex-row font-semibold h-full items-center justify-center md:justify-start p-1 md:p-0 rounded-md transition w-full active:bg-crust active:ring-accent-light active:shadow-sm hover:bg-crust hover:ring-accent-light hover:shadow-sm", !IsMenuOpen ? "justify-center" : "", isRandomLoading ? "bg-crust font-bold ring-accent-light shadow-sm" : "") role="button" title="Random" @onclick="@OnRandomClickCore">
-            <div class="flex items-center justify-center p-1.5 md:p-3">
-                <Icon class=@ClassNames.Combine("md:text-2xl", isRandomLoading ? "motion-safe:animate-spin" : "") Name="@IconName.Casino" Size="@TextSize.ExtraLarge" />
-            </div>
-            <span class=@ClassNames.Combine("ease-in font-semibold md:ml-0.5 md:mr-2.5 p-0.5 md:p-2 rounded-md text-xs md:text-lg transition", !IsMenuOpen ? "hidden opacity-0" : "opacity-100")>Random</span>
+        <span class=@ClassNames.Combine([.. DetermineClassNames(IsMenuOpen), "cursor-pointer", IsRandomLoading ? "active" : ""]) @onclick="@OnRandomClickCore">
+            @NavLinkBody(NavigationItems.Random, IsRandomLoading)
         </span>
     </div>
 </nav>
 
 @code {
 
-    private bool isRandomLoading;
+    private bool IsRandomLoading;
 
     [EditorRequired]
     [Parameter]
@@ -45,11 +32,38 @@
     [Parameter]
     public EventCallback OnRandomClick { get; init; }
 
+    private static IEnumerable<string> DetermineClassNames(bool open)
+    {
+        yield return "nav-link";
+
+        if (!open)
+        {
+            yield return "justify-center";
+        }
+    }
+
+    private RenderFragment NavLink(NavigationItem item) => __builder =>
+    {
+        <NavLink ActiveClass="active" class=@ClassNames.Combine([.. DetermineClassNames(IsMenuOpen)]) href="@item.Path" title="@item.Label" Match="@item.Match" @key="@item.Path">
+            @NavLinkBody(item, false)
+        </NavLink>
+    };
+
+    private RenderFragment NavLinkBody(NavigationItem item, bool animate = false) => __builder =>
+    {
+        <div class="flex items-center justify-center p-1.5 md:p-3">
+            <Icon class=@ClassNames.Combine("md:text-2xl", animate ? "motion-safe:animate-spin" : "") Name="@item.Icon.Name" Filled="@item.Icon.Filled" Size="@TextSize.ExtraLarge" />
+        </div>
+        <span class=@ClassNames.Combine("ease-in font-semibold md:ml-0.5 md:mr-2.5 p-0.5 md:p-2 rounded-md text-xs md:text-lg transition", !IsMenuOpen ? "hidden opacity-0" : "opacity-100")>@item.Label</span>
+    };
+
     private async Task OnRandomClickCore()
     {
-        isRandomLoading = true;
-        await OnRandomClick.InvokeAsync();
-        isRandomLoading = false;
+        if (!Interlocked.Exchange(ref IsRandomLoading, true))
+        {
+            await OnRandomClick.InvokeAsync();
+            IsRandomLoading = false;
+        }
     }
 
 }

--- a/src/App/UI/Components/Layout/Navigation.razor.cs
+++ b/src/App/UI/Components/Layout/Navigation.razor.cs
@@ -3,15 +3,30 @@ using Wadio.App.UI.Interop;
 
 namespace Wadio.App.UI.Components.Layout;
 
-internal sealed record NavigationItem( IconName Icon, string Label, string Path )
+internal static class NavigationItems
+{
+    public static readonly NavigationItem[] All = [
+        new(IconName.Explore, "Explore", "/explore"),
+        new(IconName.Search, "Search", "/search")];
+
+    public static readonly NavigationItem Home = new( IconName.Home, "Discover", "/" )
+    {
+        Match = NavLinkMatch.All
+    };
+
+    public static readonly NavigationItem Random = new( new( IconName.Casino, true ), "Random", "#" )
+    {
+        Match = NavLinkMatch.All
+    };
+}
+
+internal sealed record NavigationItem( NavigationIcon Icon, string Label, string Path )
 {
     public DOMBreakpoint? Breakpoint { get; init; }
     public NavLinkMatch Match { get; init; } = NavLinkMatch.Prefix;
 }
 
-internal static class NavigationItems
+internal sealed record NavigationIcon( IconName Name, bool Filled = false )
 {
-    public static readonly NavigationItem[] Values = [
-        new(IconName.Explore, "Explore", "/explore"),
-        new(IconName.Search, "Search", "/search")];
+    public static implicit operator NavigationIcon( IconName icon ) => new( icon );
 }

--- a/src/App/UI/Components/Layout/Navigation.razor.css
+++ b/src/App/UI/Components/Layout/Navigation.razor.css
@@ -1,0 +1,13 @@
+::deep .nav-link {
+    @apply drop-shadow-sm ease-in flex flex-col font-semibold h-full items-center justify-center no-underline p-1 rounded-md transition w-full;
+    @apply active:bg-crust active:ring-accent-light active:shadow-sm active:text-gray-200;
+    @apply hover:bg-crust hover:ring-accent-light hover:shadow-sm;
+
+    @variant md {
+        @apply flex-row justify-start p-0;
+    }
+}
+
+::deep .nav-link.active {
+    @apply bg-crust font-bold ring-accent-light shadow-sm;
+}

--- a/src/App/UI/Components/Marquee.razor
+++ b/src/App/UI/Components/Marquee.razor
@@ -1,3 +1,4 @@
+@using Wadio.App.UI.Infrastructure
 @implements IAsyncDisposable
 
 @inject DOMInterop Dom
@@ -62,12 +63,9 @@
             interop = default;
         }
 
-        foreach (var value in resize)
-        {
-            await value.DisposeAsync();
-        }
-
+        await Disposer.DisposeAsync(resize);
         resize.Clear();
+
         target = default;
         parent = default;
     }
@@ -79,8 +77,8 @@
             interop = await Interop.Attach(target!.Value, parent!.Value);
             await Measure();
 
-            resize.Add(await Dom.AddResizeObserver(parent!.Value));
-            resize.Add(await Dom.AddResizeObserver(target!.Value));
+            resize.Add(await Dom.AddResizeObserver(parent.Value));
+            resize.Add(await Dom.AddResizeObserver(target.Value));
         }
     }
 
@@ -94,6 +92,11 @@
         }
 
         var measurement = await interop.Measure();
+        if (measurement is null)
+        {
+            return;
+        }
+
         if (marquee != measurement.IsOverflowing)
         {
             if (marquee = measurement.IsOverflowing)

--- a/src/App/UI/Components/Routing/NavigationExtensions.cs
+++ b/src/App/UI/Components/Routing/NavigationExtensions.cs
@@ -25,6 +25,7 @@ internal static class NavigationExtensions
     {
         ArgumentNullException.ThrowIfNull( navigation );
 
-        navigation.NavigateTo( $"/station/{stationId}" );
+        var url = navigation.ToAbsoluteUri( $"/station/{stationId}" );
+        navigation.NavigateTo( url.AbsoluteUri );
     }
 }

--- a/src/App/UI/Components/SearchContext.cs
+++ b/src/App/UI/Components/SearchContext.cs
@@ -38,7 +38,7 @@ public sealed class SearchRequestEventArgs( string? query ) : EventArgs
     public void Handled( ) => Continue = false;
 }
 
-public delegate ValueTask<bool> SearchRequestSubscriber( SearchRequestEventArgs e, CancellationToken cancellation );
+public delegate ValueTask SearchRequestSubscriber( SearchRequestEventArgs e, CancellationToken cancellation );
 
 sealed file class Subscription( SearchRequestSubscriber subscriber, IList<SearchRequestSubscriber> subscribers ) : IDisposable
 {

--- a/src/App/UI/Infrastructure/Disposer.cs
+++ b/src/App/UI/Infrastructure/Disposer.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+
+namespace Wadio.App.UI.Infrastructure;
+
+internal static class Disposer
+{
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static void Dispose( params IEnumerable<IDisposable> resources )
+    {
+        ArgumentNullException.ThrowIfNull( resources );
+
+        foreach( var resource in resources )
+        {
+            resource.Dispose();
+        }
+    }
+
+    [MethodImpl( MethodImplOptions.AggressiveInlining )]
+    public static async ValueTask DisposeAsync( params IEnumerable<IAsyncDisposable> resources )
+    {
+        ArgumentNullException.ThrowIfNull( resources );
+
+        foreach( var resource in resources )
+        {
+            await resource.DisposeAsync();
+        }
+    }
+}

--- a/src/App/UI/Interop/MapInterop.cs
+++ b/src/App/UI/Interop/MapInterop.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using Wadio.App.UI.Infrastructure;
 
 namespace Wadio.App.UI.Interop;
 
@@ -112,6 +113,7 @@ internal sealed class MapReference( MapEventsReference events, IJSObjectReferenc
 
             await map.InvokeVoidAsync( "dispose" );
             await map.DisposeAsync();
+            await Disposer.DisposeAsync( map );
         }
         catch( JSDisconnectedException ) { }
 

--- a/src/App/UI/Interop/Marquee.module.ts
+++ b/src/App/UI/Interop/Marquee.module.ts
@@ -1,5 +1,7 @@
 import mobile from 'is-mobile';
 
+import { animate } from './core';
+
 export function attach(target: HTMLElement, parent: HTMLElement) {
   const handler = (e: PointerEvent) => {
     e.stopPropagation();
@@ -14,18 +16,28 @@ export function attach(target: HTMLElement, parent: HTMLElement) {
 
   return {
     dispose() {
-      parent.removeEventListener('contextmenu', handler);
+      parent?.removeEventListener('contextmenu', handler);
     },
 
     measure() {
-      const innerWidth = target.scrollWidth;
-      const outerWidth = parent.clientWidth;
+      if (!target || !parent) {
+        return;
+      }
 
-      return {
-        overflowing: innerWidth > outerWidth,
-        innerWidth,
-        outerWidth
-      };
+      return animate(() => {
+        if (!target || !parent) {
+          return;
+        }
+
+        const innerWidth = target.scrollWidth;
+        const outerWidth = parent.clientWidth;
+
+        return {
+          overflowing: innerWidth > outerWidth,
+          innerWidth,
+          outerWidth
+        };
+      });
     }
   };
 };

--- a/src/App/UI/Interop/MarqueeInterop.cs
+++ b/src/App/UI/Interop/MarqueeInterop.cs
@@ -29,5 +29,5 @@ internal sealed class MarqueeReference( IJSObjectReference reference ) : IAsyncD
         await reference.DisposeAsync();
     }
 
-    public ValueTask<MarqueeMeasurement> Measure( CancellationToken cancellation = default ) => reference.InvokeAsync<MarqueeMeasurement>( "measure", cancellation );
+    public ValueTask<MarqueeMeasurement?> Measure( CancellationToken cancellation = default ) => reference.InvokeAsync<MarqueeMeasurement?>( "measure", cancellation );
 }

--- a/src/App/UI/Pages/Search.razor
+++ b/src/App/UI/Pages/Search.razor
@@ -1,5 +1,6 @@
-@using System.Runtime.CompilerServices
+@using ESCd.Extensions.Http
 @using Microsoft.Extensions.ObjectPool
+@using System.Diagnostics
 @using Wadio.App.UI.Components.Routing
 
 @page "/search"
@@ -8,6 +9,7 @@
 
 @inject IWadioApi Api
 @inject NavigationManager Navigation
+@inject ObjectPool<QueryStringBuilder> QueryBuilderPool
 @inject ObjectPool<HashSet<Uri>> UriSetPool
 
 <HeadContent>
@@ -25,38 +27,38 @@
             <div class="flex flex-row gap-5 items-stretch max-h-64 overflow-x-auto px-0.5 pb-2.5 scroll-px-0.5 snap-x">
                 <div class="flex flex-col max-w-72 min-w-44 shrink-0 snap-start space-y-1">
                     <label class="font-bold text-gray-400! text-sm uppercase">Order</label>
-                    <InputFilterEnum class="h-full ring-accent-subtle" TValue="StationOrderBy" @bind-Value="@parameters.Order" Disabled="@(!State.IsLoaded)" />
+                    <InputFilterEnum class="h-full ring-accent-subtle" TValue="StationOrderBy" @bind-Value="@parameters.Order" Disabled="@(!State.IsLoaded || State.IsSearching)" />
                     <ValidationMessage For="@(() => parameters.Order)" />
                 </div>
 
                 <div class="flex flex-col max-w-72 min-w-44 shrink-0 snap-start space-y-1">
                     <label class="font-bold text-gray-400! text-sm uppercase">Tag</label>
-                    <InputFilter class="h-full ring-accent-subtle" TValue="string" @bind-Value="@parameters.Tag" Disabled="@(!State.IsLoaded)" Filter="@StringFilterProvider.OrdinalIgnoreCase" Options="@State.Tags" />
+                    <InputFilter class="h-full ring-accent-subtle" TValue="string" @bind-Value="@parameters.Tag" Disabled="@(!State.IsLoaded || State.IsSearching)" Filter="@StringFilterProvider.OrdinalIgnoreCase" Options="@(State.IsLoaded? State.Tags: [])" />
                     <ValidationMessage For="@(() => parameters.Tag)" />
                 </div>
 
                 <div class="flex flex-col max-w-72 min-w-44 shrink-0 snap-start space-y-1">
                     <label class="font-bold text-gray-400! text-sm uppercase">Country</label>
-                    <InputFilter class="h-full ring-accent-subtle" TValue="string" @bind-Value="@parameters.CountryCode" Disabled="@(!State.IsLoaded)" Filter="@StringFilterProvider.OrdinalIgnoreCase" Options="@State.Countries" />
+                    <InputFilter class="h-full ring-accent-subtle" TValue="string" @bind-Value="@parameters.CountryCode" Disabled="@(!State.IsLoaded || State.IsSearching)" Filter="@StringFilterProvider.OrdinalIgnoreCase" Options="@(State.IsLoaded? State.Countries: [])" />
                     <ValidationMessage For="@(() => parameters.CountryCode)" />
                 </div>
 
                 <div class="flex flex-col max-w-72 min-w-44 shrink-0 snap-start space-y-1">
                     <label class="font-bold text-gray-400! text-sm uppercase">Language</label>
-                    <InputFilter class="h-full ring-accent-subtle" TValue="string" @bind-Value="@parameters.LanguageCode" Disabled="@(!State.IsLoaded)" Filter="@StringFilterProvider.OrdinalIgnoreCase" Options="@State.Languages" />
+                    <InputFilter class="h-full ring-accent-subtle" TValue="string" @bind-Value="@parameters.LanguageCode" Disabled="@(!State.IsLoaded || State.IsSearching)" Filter="@StringFilterProvider.OrdinalIgnoreCase" Options="@(State.IsLoaded? State.Languages: [])" />
                     <ValidationMessage For="@(() => parameters.LanguageCode)" />
                 </div>
 
                 <div class="flex flex-col max-w-72 min-w-44 shrink-0 snap-start space-y-1">
                     <label class="font-bold text-gray-400! text-sm uppercase">Codec</label>
-                    <InputFilterEnum class="h-full ring-accent-subtle" TValue="Codec" @bind-Value="@parameters.Codec" Disabled="@(!State.IsLoaded)" />
+                    <InputFilterEnum class="h-full ring-accent-subtle" TValue="Codec" @bind-Value="@parameters.Codec" Disabled="@(!State.IsLoaded || State.IsSearching)" />
                     <ValidationMessage For="@(() => parameters.Codec)" />
                 </div>
             </div>
         </EditForm>
 
         <div class="flex flex-col gap-5 p-2.5 w-full">
-            @if (!State.IsSearching)
+            @if (State.IsLoaded && !State.IsSearching)
             {
                 @if (State.Stations.Length is not 0)
                 {
@@ -76,15 +78,15 @@
                 }
                 else
                 {
-                    <div class="flex flex-col h-full items-center justify-center space-y-2.5">
+                    <div class="absolute flex flex-col h-2/3 items-center justify-center space-y-2.5 w-full">
                         <Icon Name="IconName.SentimentDissatisfied" Size="TextSize.ExtraLarge6" />
-                        <span class="font-semibold text-lg">No results!</span>
+                        <span class="font-semibold text-lg">Nothing Found</span>
                     </div>
                 }
             }
             else
             {
-                <div class="flex flex-row h-full items-center justify-center">
+                <div class="absolute flex flex-row h-2/3 items-center justify-center w-full">
                     <Loading Size="@TextSize.ExtraLarge4" />
                 </div>
             }
@@ -95,8 +97,10 @@
 @code {
 
     private EditForm? form;
+    private bool initialized;
+    private IDisposable? onFieldChanged;
+    private IDisposable? onSearchRequested;
     private SearchStationsParameters parameters = new() { Count = SearchState.StationCount };
-    private IDisposable? subscription;
     private FormValidator? validator;
 
     [CascadingParameter]
@@ -126,11 +130,8 @@
     {
         if (disposing)
         {
-            subscription?.Dispose();
-            if (form?.EditContext is not null)
-            {
-                form.EditContext.OnFieldChanged -= OnFieldChanged;
-            }
+            onFieldChanged?.Dispose();
+            onSearchRequested?.Dispose();
         }
 
         base.Dispose(disposing);
@@ -178,24 +179,15 @@
     {
         if (firstRender)
         {
-            subscription = Context.OnSearchRequested(async (e, _) =>
-            {
-                e.Handled();
-                return await ExecuteSearch(parameters =>
-    {
-                parameters.Offset = default;
-                parameters.Name = e.Query;
-                parameters.Order = StationOrderBy.Name;
-            });
-            });
+            onSearchRequested = Context.OnSearchRequested(OnSearchRequested);
+            onFieldChanged ??= form!.EditContext!.AddFieldChangedListener(OnFieldChanged);
         }
     }
 
-    private async void OnFieldChanged(object? sender, FieldChangedEventArgs e)
+    private async void OnFieldChanged(EditContext context, FieldChangedEventArgs e)
     {
         if (e.FieldIdentifier.FieldName is nameof(parameters.Codec) or nameof(parameters.CountryCode) or nameof(parameters.LanguageCode) or nameof(parameters.Order) or nameof(parameters.Tag))
         {
-            var context = Unsafe.As<EditContext>(sender)!;
             if (context.Validate())
             {
                 await ExecuteSearch(parameters =>
@@ -213,6 +205,17 @@
         await Mutate(state => SearchState.ContinueSearch(Api.Stations, parameters, state));
     }
 
+    private async ValueTask OnSearchRequested(SearchRequestEventArgs e, CancellationToken _)
+    {
+        e.Handled();
+        await ExecuteSearch(parameters =>
+        {
+            parameters.Offset = default;
+            parameters.Name = e.Query;
+            parameters.Order = StationOrderBy.Name;
+        });
+    }
+
     private Task OnSearchSubmit(EditContext context)
     {
         if (context.IsModified())
@@ -227,11 +230,55 @@
         return Task.CompletedTask;
     }
 
-    public override async Task SetParametersAsync(ParameterView view)
+    private async Task OnSetParameters(SearchStationsParameters parameters)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var changing = !State.IsLoaded || this.parameters != parameters;
+        if (changing)
+        {
+            this.parameters = parameters;
+        }
+
+        var restored = false;
+        if (!Interlocked.CompareExchange(ref initialized, true, false))
+        {
+            if ((restored = TryRestoreFromPersistence(RestoreKey(parameters))))
+            {
+                await Mutate(state => state with { IsLoaded = true });
+            }
+        }
+
+        if (!restored && changing)
+        {
+            if (!State.IsLoaded)
+            {
+                await Mutate(state => SearchState.Load(Api, state));
+            }
+
+            await Mutate(state => SearchState.Search(Api.Stations, parameters, state));
+        }
+
         if (form?.EditContext is not null)
         {
-            form.EditContext.OnFieldChanged -= OnFieldChanged;
+            if (State.IsLoaded && changing)
+            {
+                form.EditContext.MarkAsUnmodified();
+            }
+
+            if (onFieldChanged is null)
+            {
+                onFieldChanged = form.EditContext.AddFieldChangedListener(OnFieldChanged);
+            }
+        }
+    }
+
+    public override Task SetParametersAsync(ParameterView view)
+    {
+        if (onFieldChanged is not null)
+        {
+            onFieldChanged.Dispose();
+            onFieldChanged = default;
         }
 
         view.SetParameterProperties(this);
@@ -245,21 +292,47 @@
             Tag = Tag,
         };
 
-        if (!State.IsLoaded || this.parameters != parameters)
+        return OnSetParametersCore(this, parameters);
+
+        [DebuggerDisableUserUnhandledExceptions]
+        static async Task OnSetParametersCore(Search search, SearchStationsParameters parameters)
         {
-            this.parameters = parameters;
-            if (await Mutate(state => SearchState.Search(Api.Stations, parameters, state)))
+            var task = search.OnSetParameters(parameters);
+            if (task.Status is not TaskStatus.RanToCompletion && task.Status is not TaskStatus.Canceled)
             {
-                form!.EditContext!.MarkAsUnmodified();
+                search.StateHasChanged();
+                try
+                {
+                    await task;
+                }
+                catch (Exception e) when (e is not NavigationException)
+                {
+                    Debugger.BreakForUserUnhandledException(e);
+                    if (!task.IsCanceled && e is not ObjectDisposedException)
+                    {
+                        throw;
+                    }
+                }
             }
         }
-
-        if (!State.IsLoaded)
-        {
-            await Mutate(state => SearchState.Load(Api, state));
-        }
-
-        form!.EditContext!.OnFieldChanged += OnFieldChanged;
     }
 
+    private string RestoreKey(SearchStationsParameters parameters)
+    {
+        var builder = QueryBuilderPool.Get();
+        try
+        {
+            return builder.Append(nameof(parameters.Count), parameters.Count)
+            .Append(nameof(parameters.CountryCode), parameters.CountryCode)
+            .Append(nameof(parameters.LanguageCode), parameters.LanguageCode)
+            .Append(nameof(parameters.Name), parameters.Name)
+            .Append(nameof(parameters.Order), parameters.Order?.ToString())
+            .Append(nameof(parameters.Tag), parameters.Tag)
+            .ToString();
+        }
+        finally
+        {
+            QueryBuilderPool.Return(builder);
+        }
+    }
 }

--- a/src/App/UI/Pages/Search.razor.cs
+++ b/src/App/UI/Pages/Search.razor.cs
@@ -24,19 +24,10 @@ public sealed record SearchState : State<SearchState>
 
         return state with
         {
-            Countries = [ .. await api.Countries.Get().Select(static country => new FilterOption(country.Name, country.Code)
-            {
-                Count = country.Count
-            }).ToListAsync() ],
-            IsLoaded = true,
-            Languages = [ .. await api.Languages.Get().Select(static language => new FilterOption(language.Name, language.Code)
-            {
-                Count = language.Count
-            }).ToListAsync()],
-            Tags = [ .. await api.Tags.Get().Select(static tag => new FilterOption(tag.Name, tag.Name)
-            {
-                Count = tag.Count
-            }).ToListAsync()],
+            Countries = [ .. await api.Countries.Get().Select( static country => new FilterOption( country.Name, country.Code, country.Count ) ).ToListAsync() ],
+            IsLoaded = OperatingSystem.IsBrowser(),
+            Languages = [ .. await api.Languages.Get().Select( static language => new FilterOption( language.Name, language.Code, language.Count ) ).ToListAsync() ],
+            Tags = [ .. await api.Tags.Get().Select( static tag => new FilterOption( tag.Name, tag.Name, tag.Count ) ).ToListAsync() ],
         };
     }
 
@@ -69,10 +60,10 @@ public sealed record SearchState : State<SearchState>
 
         await foreach( var mutation in ContinueSearch( api, parameters, state ) )
         {
-            yield return state = mutation with
+            yield return state = (mutation with
             {
                 IsSearching = true,
-            };
+            });
         }
 
         yield return state with

--- a/src/App/UI/Pages/Station.razor
+++ b/src/App/UI/Pages/Station.razor
@@ -70,7 +70,7 @@
 
             <div class="flex flex-col md:flex-row gap-2.5 p-2.5 md:pb-0">
                 <div class="flex flex-col space-y-2.5 w-full md:max-w-1/3">
-                    @if (TryGetMetadataVisibility(PlayerContext, State, out var title, out var artist, out var album))
+                    @if (PlayerContext.Station?.Id == State.Station.Id)
                     {
                         <div class="bg-crust flex flex-col p-4 ring-accent rounded-md shadow-sm space-y-2 w-full">
                             <div class="drop-shadow-xs flex flex-row items-center justify-between space-x-2.5 text-lg">
@@ -78,33 +78,36 @@
                                 <Icon class="drop-shadow-md font-medium text-accent/90" Name="@IconName.AnimatedWaves" Size="@TextSize.ExtraLarge4" />
                             </div>
 
-                            <Divider class="p-1 px-0.5" />
+                            @if (TryGetMetadataVisibility(PlayerContext, State, out var title, out var artist, out var album))
+                            {
+                                <Divider class="p-1 px-0.5" />
 
-                            <div class="flex flex-col italic pt-0.5 space-y-2 w-full">
-                                @if (title)
-                                {
-                                    <div class="flex flex-col space-y-1">
-                                        <label class="font-bold not-italic text-gray-400! text-xs! uppercase">title</label>
-                                        <p>@PlayerContext.Metadata!.Title</p>
-                                    </div>
-                                }
+                                <div class="flex flex-col italic pt-0.5 space-y-2 w-full">
+                                    @if (title)
+                                    {
+                                        <div class="flex flex-col space-y-1">
+                                            <label class="font-bold not-italic text-gray-400! text-xs! uppercase">title</label>
+                                            <p>@PlayerContext.Metadata!.Title</p>
+                                        </div>
+                                    }
 
-                                @if (artist)
-                                {
-                                    <div class="flex flex-col space-y-1">
-                                        <label class="font-bold not-italic text-gray-400! text-xs! uppercase">artist</label>
-                                        <p>@PlayerContext.Metadata!.Artist</p>
-                                    </div>
-                                }
+                                    @if (artist)
+                                    {
+                                        <div class="flex flex-col space-y-1">
+                                            <label class="font-bold not-italic text-gray-400! text-xs! uppercase">artist</label>
+                                            <p>@PlayerContext.Metadata!.Artist</p>
+                                        </div>
+                                    }
 
-                                @if (album)
-                                {
-                                    <div class="flex flex-col space-y-1">
-                                        <label class="font-bold not-italic text-gray-400! text-xs! uppercase">album</label>
-                                        <p>@PlayerContext.Metadata!.Album</p>
-                                    </div>
-                                }
-                            </div>
+                                    @if (album)
+                                    {
+                                        <div class="flex flex-col space-y-1">
+                                            <label class="font-bold not-italic text-gray-400! text-xs! uppercase">album</label>
+                                            <p>@PlayerContext.Metadata!.Album</p>
+                                        </div>
+                                    }
+                                </div>
+                            }
                         </div>
                     }
 

--- a/src/App/UI/_Imports.Button.css
+++ b/src/App/UI/_Imports.Button.css
@@ -7,6 +7,10 @@
         @apply disabled:cursor-not-allowed disabled:text-gray-500;
     }
 
+    &.dark:not(.icon) {
+        @apply !bg-mantle;
+    }
+
     &.icon {
         @apply btn-icon;
     }
@@ -22,6 +26,10 @@
     &:disabled {
         @apply cursor-not-allowed text-gray-500;
         @apply hover:bg-transparent hover:drop-shadow-none hover:ring-0 hover:shadow-none;
+    }
+
+    &.dark:hover {
+        @apply !bg-mantle;
     }
 }
 

--- a/src/App/UI/wwwroot/manifest.json
+++ b/src/App/UI/wwwroot/manifest.json
@@ -88,6 +88,7 @@
   "id": "wadio.live",
   "name": "Wadio",
   "prefer_related_applications": false,
+  "orientation": "portrait-primary",
   "short_name": "Wadio",
   "start_url": "/",
   "theme_color": "#4b004f"

--- a/src/App/Web/Configuration/ConfigureJson.cs
+++ b/src/App/Web/Configuration/ConfigureJson.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Wadio.App.Abstractions.Json;
+using Wadio.App.UI.Components;
 
 namespace Wadio.App.Web.Configuration;
 
@@ -31,6 +32,7 @@ internal sealed class ConfigureJson : IConfigureOptions<Microsoft.AspNetCore.Htt
         options.DictionaryKeyPolicy = new JsonPathNamingPolicy( JsonNamingPolicy.CamelCase );
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
+        options.TypeInfoResolverChain.Insert( 0, ComponentsJsonContext.Default );
         options.TypeInfoResolverChain.Insert( 0, AppJsonContext.Default );
     }
 }


### PR DESCRIPTION
- [NEW] persist+restore `SearchState`, keyed by the current `SearchStationsParameters`
- [NEW] focus the search input when navigating to search from search
- [NEW] display "Currently Playing" on current station page, regardless of metadata presence
- [NEW] improve ux consistency of "Quick Search"
- [NEW] consolidate rendering of `Navigation`
- [FIX] loading indicators when executing a search